### PR TITLE
fix: blog sorting by publishDate

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,5 +20,5 @@ export type NavLink = {
 // Markdown
 export type Frontmatter = {
   title: string
-  // publishDate: string
+  publishDate: string
 }

--- a/src/posts/2023-11-08-pdx-dao-is-dead.md
+++ b/src/posts/2023-11-08-pdx-dao-is-dead.md
@@ -1,6 +1,6 @@
 ---
 title: PDX DAO is Dead
-# publishDate: November 8th, 2023
+publishDate: November 8, 2023
 ---
 
 November 8th, 2023

--- a/src/posts/2024-01-30-build-your-own-fun-dao.md
+++ b/src/posts/2024-01-30-build-your-own-fun-dao.md
@@ -1,6 +1,6 @@
 ---
 title: Build your own Fun DAO
-# publishDate: Jan 30, 2024
+publishDate: January 30, 2024
 ---
 
 Jan 30, 2024


### PR DESCRIPTION
## Description
- Makes `publishDate` front matter field required
- Uses this to sort blog posts; newest at top
- Adds clear error handling message to alert user at build time
- Renames existing blog posts; named in `YYYY-MM-DD-kebab-case-title.md` format for clarity and organization, but this format is not required